### PR TITLE
記事ページでaタグの文章がコンテンツ領域をはみ出る #49

### DIFF
--- a/style.css
+++ b/style.css
@@ -278,6 +278,10 @@ div.entry-content blockquote {
   border-left-color: #CCC;
 }
 
+div.entry-content a {
+  word-break: break-all;
+}
+
 .col-8-12-custom {
   width: 60%;
 }


### PR DESCRIPTION
# 元チケット
https://github.com/yheihei/wordpress-yhei-web-design/issues/49
# テスト
前提：長いリンクを入れた記事が入っている
* http://localhost:8000/?p=43 にアクセス
下記のように折り返されている
<img width="462" alt="スクリーンショット 2021-03-31 19 09 47" src="https://user-images.githubusercontent.com/20881553/113128365-b1090a80-9254-11eb-834f-396a00f356a1.png">
